### PR TITLE
fix: emit declaration files to dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "emitDeclarationOnly": true,
 
     "outDir": "dist",
-    "rootDir": ".",
+    "rootDir": "./src",
 
     "skipLibCheck": true
   }


### PR DESCRIPTION
Currently types are emited into `dist/src`