### PR TITLE
bug: Set the correct cache headers for static files

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -47,7 +47,7 @@ const remixFastify: FastifyPluginAsync<PluginOptions> = async (
     root: fullOptions.assetsBuildDirectory,
     prefix: "/",
     wildcard: false,
-    maxAge: 31536000,
+    maxAge: "1y",
     dotfiles: "allow",
   });
 
@@ -57,7 +57,7 @@ const remixFastify: FastifyPluginAsync<PluginOptions> = async (
     root: path.join(process.cwd(), "public"),
     prefix: "/",
     wildcard: false,
-    maxAge: 3600,
+    maxAge: "1d",
     dotfiles: "allow",
   });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -47,6 +47,7 @@ const remixFastify: FastifyPluginAsync<PluginOptions> = async (
     root: fullOptions.assetsBuildDirectory,
     prefix: "/",
     wildcard: false,
+    immutable: true,
     maxAge: "1y",
     dotfiles: "allow",
   });


### PR DESCRIPTION
The cache header values are currently passed as seconds instead of ms, which the library that `@fastify/static` uses expects (https://www.npmjs.com/package/send#maxage).

You can pass a string value which is correctly parsed in the the right amount of ms.

There's another issue I've noticed, the `assetsBuildDirectory` files do not get handled by the stricter handler (with immutable).

I've tried to set the prefix to `/build/` so they're correctly picked up, but I receive errors for double registration of routes then.
Unsure how to properly resolve that issue.