### PR TITLE
expose Remix's `NodeRequest` to `getLoadContext`

### DIFF
--- a/.changeset/gold-parents-press.md
+++ b/.changeset/gold-parents-press.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": minor
+---
+
+expose Remix's `NodeRequest` to `getLoadContext`

--- a/packages/remix-fastify/src/server.ts
+++ b/packages/remix-fastify/src/server.ts
@@ -24,6 +24,7 @@ import {
 export type GetLoadContextFunction = (
   request: FastifyRequest,
   reply: FastifyReply,
+  remixRequest: NodeRequest,
 ) => AppLoadContext;
 
 export type RequestHandler = (

--- a/packages/remix-fastify/src/server.ts
+++ b/packages/remix-fastify/src/server.ts
@@ -49,7 +49,7 @@ export function createRequestHandler({
     let remixRequest = createRemixRequest(request, reply);
     let loadContext =
       typeof getLoadContext === "function"
-        ? getLoadContext(request, reply)
+        ? getLoadContext(request, reply, remixRequest)
         : undefined;
 
     let response = (await handleRequest(


### PR DESCRIPTION
This patch updates `server.ts` to add a third argument to `getLoadContext` which is the transformed Remix Request object. This is helpful for us at my company as we're switching from Cloudflare Workers to a NodeJS based Remix architecture and much of our existing `getLoadContext` is based off of a `Request` object being available.

I also think this will help others write more portable code as well.