### PR TITLE
feat: make remix root directory configurable

### DIFF
--- a/.changeset/clever-shoes-punch.md
+++ b/.changeset/clever-shoes-punch.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": minor
+---
+
+Make Remix root directory location configurable.

--- a/packages/remix-fastify/src/utils.ts
+++ b/packages/remix-fastify/src/utils.ts
@@ -12,9 +12,14 @@ export interface StaticFile {
 
 export function getStaticFiles(
   assetsBuildDirectory: string,
-  publicPath: string
+  publicPath: string,
+  rootDir: string
 ): Array<StaticFile> {
-  let staticFilePaths = glob.sync(`public/**/*`, { dot: true, nodir: true });
+  let staticFilePaths = glob.sync(`public/**/*`, {
+    dot: true,
+    nodir: true,
+    cwd: rootDir,
+  });
 
   return staticFilePaths.map((filepath) => {
     let isBuildAsset = filepath.startsWith(assetsBuildDirectory);


### PR DESCRIPTION
## Summary

This PR enables you to use this plugin when running fastify from a different directory to the remix root.

* updates `remixFastify` plugin to take `rootDir` as an option, for if remix root is different to `process.cwd()`
* passes `rootDir` to `glob.sync` as `cwd` option