### PR TITLE
fix: match static files in dev based on the pathname to fix HMR

### DIFF
--- a/.changeset/gorgeous-carpets-crash.md
+++ b/.changeset/gorgeous-carpets-crash.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": minor
+---
+
+Match static files in development based on the pathname to fix HMR.

--- a/example/package.json
+++ b/example/package.json
@@ -13,15 +13,15 @@
   },
   "dependencies": {
     "@mcansh/remix-fastify": "workspace:*",
-    "@remix-run/node": "1.12.0",
-    "@remix-run/react": "1.12.0",
+    "@remix-run/node": "1.13.0",
+    "@remix-run/react": "1.13.0",
     "fastify": "^4.12.0",
     "isbot": "^3.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "1.12.0",
+    "@remix-run/dev": "1.13.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "dotenv": "^16.0.3",

--- a/example/remix.config.js
+++ b/example/remix.config.js
@@ -6,7 +6,6 @@ module.exports = {
   appDirectory: "app",
   assetsBuildDirectory: "public/build",
   serverBuildPath: "build/index.js",
-  publicPath: "/build/",
   future: {
     unstable_dev: true,
     v2_routeConvention: true,

--- a/packages/remix-fastify/src/plugin.ts
+++ b/packages/remix-fastify/src/plugin.ts
@@ -85,13 +85,12 @@ let remixFastify: FastifyPluginAsync<PluginOptions> = async (
         rootDir
       );
 
-      let pathname = new URL(
-        request.url,
-        request.protocol + "://" + request.hostname
-      ).pathname;
+      let origin = `${request.protocol}://${request.hostname}`;
+      let url = new URL(`${origin}${request.url}`);
+
       let staticFile = staticFiles.find((file) => {
         return (
-          pathname ===
+          url.pathname ===
           (file.isBuildAsset ? file.browserAssetUrl : file.filePublicPath)
         );
       });

--- a/packages/remix-fastify/src/plugin.ts
+++ b/packages/remix-fastify/src/plugin.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { pathToFileURL } from "node:url";
+import { pathToFileURL, URL } from "node:url";
 import fastifyStatic from "@fastify/static";
 import type { ServerBuild } from "@remix-run/node";
 import type { FastifyPluginAsync, FastifyReply } from "fastify";
@@ -85,9 +85,13 @@ let remixFastify: FastifyPluginAsync<PluginOptions> = async (
         rootDir
       );
 
+      let pathname = new URL(
+        request.url,
+        request.protocol + "://" + request.hostname
+      ).pathname;
       let staticFile = staticFiles.find((file) => {
         return (
-          request.url ===
+          pathname ===
           (file.isBuildAsset ? file.browserAssetUrl : file.filePublicPath)
         );
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,9 @@ importers:
   example:
     specifiers:
       '@mcansh/remix-fastify': workspace:*
-      '@remix-run/dev': 1.12.0
-      '@remix-run/node': 1.12.0
-      '@remix-run/react': 1.12.0
+      '@remix-run/dev': 1.13.0
+      '@remix-run/node': 1.13.0
+      '@remix-run/react': 1.13.0
       '@types/react': ^18.0.27
       '@types/react-dom': ^18.0.10
       dotenv: ^16.0.3
@@ -51,14 +51,14 @@ importers:
       typescript: ^4.9.5
     dependencies:
       '@mcansh/remix-fastify': link:../packages/remix-fastify
-      '@remix-run/node': 1.12.0
-      '@remix-run/react': 1.12.0_biqbaboplfbrettd7655fr4n2y
+      '@remix-run/node': 1.13.0
+      '@remix-run/react': 1.13.0_biqbaboplfbrettd7655fr4n2y
       fastify: 4.12.0
       isbot: 3.6.5
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
-      '@remix-run/dev': 1.12.0
+      '@remix-run/dev': 1.13.0
       '@types/react': 18.0.27
       '@types/react-dom': 18.0.10
       dotenv: 16.0.3
@@ -2193,12 +2193,12 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@remix-run/dev/1.12.0:
-    resolution: {integrity: sha512-lBiA2FlDi+DjpOAE/vn93zFTSxudKag/FGpmbV6O+LQItDCpFARfbBMhTck/uKcc95nyhRd1GGhQ4ZDgQnyjaQ==}
+  /@remix-run/dev/1.13.0:
+    resolution: {integrity: sha512-hPqUjM9RRcz3inBOWqP3GKhggVz0a0ikWaRZpdKrhpQNCNiF6Hunbx876mJERj2YrmIzJ05eoeQmmdF6xcr4qg==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
-      '@remix-run/serve': ^1.12.0
+      '@remix-run/serve': ^1.13.0
     peerDependenciesMeta:
       '@remix-run/serve':
         optional: true
@@ -2214,7 +2214,7 @@ packages:
       '@babel/types': 7.20.7
       '@esbuild-plugins/node-modules-polyfill': 0.1.4_esbuild@0.16.3
       '@npmcli/package-json': 2.0.0
-      '@remix-run/server-runtime': 1.12.0
+      '@remix-run/server-runtime': 1.13.0
       '@vanilla-extract/integration': 6.0.2
       arg: 5.0.2
       cacache: 15.3.0
@@ -2240,6 +2240,7 @@ packages:
       ora: 5.4.1
       postcss: 8.4.21
       postcss-discard-duplicates: 5.1.0_postcss@8.4.21
+      postcss-load-config: 4.0.1_postcss@8.4.21
       postcss-modules: 6.0.0_postcss@8.4.21
       prettier: 2.7.1
       pretty-ms: 7.0.1
@@ -2258,6 +2259,7 @@ packages:
       - bufferutil
       - encoding
       - supports-color
+      - ts-node
       - utf-8-validate
     dev: true
 
@@ -2309,6 +2311,22 @@ packages:
       cookie-signature: 1.2.0
       source-map-support: 0.5.21
       stream-slice: 0.1.2
+    dev: true
+
+  /@remix-run/node/1.13.0:
+    resolution: {integrity: sha512-FDvPGaoDyon8UGYQ9DroLtiX8vFa0efBQQSHV3az0s7HbUpugw7BcA6NBW5pIs2z5sszCCeRbAgSIXcETLzfhw==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@remix-run/server-runtime': 1.13.0
+      '@remix-run/web-fetch': 4.3.2
+      '@remix-run/web-file': 3.0.2
+      '@remix-run/web-stream': 1.0.3
+      '@web3-storage/multipart-parser': 1.0.0
+      abort-controller: 3.0.0
+      cookie-signature: 1.2.0
+      source-map-support: 0.5.21
+      stream-slice: 0.1.2
+    dev: false
 
   /@remix-run/react/1.12.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-BokbMOILGJvUvwOsTXAUrucvfFz/SBKVgSHke2+89DZIU7H2Z1UWe5t8wRTfjQnfnSH2tAXCF0QxmVpo1GQ3dg==}
@@ -2322,9 +2340,29 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       react-router-dom: 6.8.0_biqbaboplfbrettd7655fr4n2y
       use-sync-external-store: 1.2.0_react@18.2.0
+    dev: true
+
+  /@remix-run/react/1.13.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-LT9TStmMavBlLqRG8u5Ku8bxdYcpIbqpmh44/f2Fyw8RvdaRCYYMkuUXsr8bhOqftaEZMFLqFhi19NWY/18DLA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.3.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-router-dom: 6.8.1_biqbaboplfbrettd7655fr4n2y
+      use-sync-external-store: 1.2.0_react@18.2.0
+    dev: false
 
   /@remix-run/router/1.3.1:
     resolution: {integrity: sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /@remix-run/router/1.3.2:
+    resolution: {integrity: sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==}
     engines: {node: '>=14'}
 
   /@remix-run/server-runtime/1.12.0:
@@ -2332,6 +2370,19 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       '@remix-run/router': 1.3.1
+      '@types/cookie': 0.4.1
+      '@types/react': 18.0.27
+      '@web3-storage/multipart-parser': 1.0.0
+      cookie: 0.4.2
+      set-cookie-parser: 2.5.1
+      source-map: 0.7.4
+    dev: true
+
+  /@remix-run/server-runtime/1.13.0:
+    resolution: {integrity: sha512-gjIW3XCeIlOt3rrOZMD6HixQydRgs1SwYjP99ZAVruG2+gNq/tL2OusMFYTLvtWrybt215tPROyF/6iTLsaO3g==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@remix-run/router': 1.3.2
       '@types/cookie': 0.4.1
       '@types/react': 18.0.27
       '@web3-storage/multipart-parser': 1.0.0
@@ -4703,7 +4754,6 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: false
 
   /fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -5111,7 +5161,7 @@ packages:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       glob: 7.2.3
       ignore: 5.2.4
       merge2: 1.4.1
@@ -6351,6 +6401,11 @@ packages:
       cookie: 0.5.0
       process-warning: 2.1.0
       set-cookie-parser: 2.5.1
+
+  /lilconfig/2.0.6:
+    resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
+    engines: {node: '>=10'}
+    dev: true
 
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -7619,6 +7674,23 @@ packages:
       postcss: 8.4.21
     dev: true
 
+  /postcss-load-config/4.0.1_postcss@8.4.21:
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      postcss: 8.4.21
+      yaml: 2.2.1
+    dev: true
+
   /postcss-modules-extract-imports/3.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
     engines: {node: ^10 || ^12 || >= 14}
@@ -7921,6 +7993,20 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-router: 6.8.0_react@18.2.0
+    dev: true
+
+  /react-router-dom/6.8.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.3.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-router: 6.8.1_react@18.2.0
+    dev: false
 
   /react-router/6.8.0_react@18.2.0:
     resolution: {integrity: sha512-760bk7y3QwabduExtudhWbd88IBbuD1YfwzpuDUAlJUJ7laIIcqhMvdhSVh1Fur1PE8cGl84L0dxhR3/gvHF7A==}
@@ -7930,6 +8016,17 @@ packages:
     dependencies:
       '@remix-run/router': 1.3.1
       react: 18.2.0
+    dev: true
+
+  /react-router/6.8.1_react@18.2.0:
+    resolution: {integrity: sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.3.2
+      react: 18.2.0
+    dev: false
 
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -9430,6 +9527,11 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  /yaml/2.2.1:
+    resolution: {integrity: sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==}
+    engines: {node: '>= 14'}
+    dev: true
 
   /yargs-parser/18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}


### PR DESCRIPTION
This fixes an issue that I observed while trying out the HMR prerelease build of Remix.

When Remix makes the HMR request, it adds a `?t=123` parameter to the URL for cache busting. The fastify adapter however did not properly resolve these static assets because it was comparing url (e.g. `build/routes/foo.js?t=123`) with the filename using string equality.

This fixes the issue by parsing the URL and comparing the pathname instead.

To make the example run locally, I also had to upgrade to Remix 1.13.0 (1.12.0 had some issues loading the flat routes properly, somehow it was looking for them in `/outes` instead `/routes` 😅 ). I included this as a separate commit in this PR but I’m happy to remove it.

It doesn't seem like there's a setup for testing the full fastify plugin end-to-end so I verified this based on the example app and `curl` instead:

## Before

<img width="956" alt="Screenshot 2023-02-24 at 01 43 50" src="https://user-images.githubusercontent.com/458591/221065695-c32a7636-0367-4333-a100-e57a03d49a68.png">

## After

<img width="888" alt="Screenshot 2023-02-24 at 01 51 23" src="https://user-images.githubusercontent.com/458591/221065708-c029100d-27a1-4d55-bfd4-9012a3cd1166.png">
