### PR TITLE
chore: add preinstall script to example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,6 +5,7 @@
   "license": "",
   "sideEffects": false,
   "scripts": {
+    "preinstall": "node ./scripts/preinstall.mjs",
     "build": "remix build",
     "dev": "remix dev -c \"node ./server.mjs\"",
     "start": "node ./server.mjs"

--- a/example/scripts/preinstall.mjs
+++ b/example/scripts/preinstall.mjs
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+let __filename = new URL(import.meta.url).pathname;
+let __dirname = path.dirname(__filename);
+
+let example = path.join(__dirname, "..");
+let pkgJsonPath = path.join(example, "package.json");
+
+let pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath));
+
+let npm = execSync(`npm info @mcansh/remix-fastify --json`).toString();
+let json = JSON.parse(npm);
+let latest = json["dist-tags"].latest;
+
+pkgJson.dependencies["@mcansh/remix-fastify"] = latest;
+delete pkgJson.scripts.preinstall;
+
+fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2), "utf-8");


### PR DESCRIPTION
this way you don't need to opt out of installing dependencies when using `create-remix`