### PR TITLE
fix: return reply from response handler

### DIFF
--- a/packages/remix-fastify/src/server.ts
+++ b/packages/remix-fastify/src/server.ts
@@ -57,7 +57,7 @@ export function createRequestHandler({
       loadContext
     )) as NodeResponse;
 
-    await sendRemixResponse(reply, response);
+    return await sendRemixResponse(reply, response);
   };
 }
 
@@ -123,4 +123,5 @@ export async function sendRemixResponse(
   } else {
     reply.send();
   }
+  return reply;
 }

--- a/packages/remix-fastify/src/server.ts
+++ b/packages/remix-fastify/src/server.ts
@@ -57,7 +57,7 @@ export function createRequestHandler({
       loadContext
     )) as NodeResponse;
 
-    return await sendRemixResponse(reply, response);
+    return sendRemixResponse(reply, response);
   };
 }
 


### PR DESCRIPTION
Enabling `@fastify/compress` causes responsed to be prematurely closed. e.g.

```ts
await app.register(import("@fastify/compress"), { global: true })
```

This seems related to this fastify v4 migration point: https://www.fastify.io/docs/latest/Guides/Migration-Guide-V4/#need-to-return-reply-to-signal-a-fork-of-the-promise-chain

(This is the first time I'm using fastify though)

closes #99