### PR TITLE
Pass request body to NodeRequest instead of whole raw request

### DIFF
--- a/packages/remix-fastify/src/server.ts
+++ b/packages/remix-fastify/src/server.ts
@@ -98,7 +98,7 @@ export function createRemixRequest(
   };
 
   if (request.method !== "GET" && request.method !== "HEAD") {
-    init.body = request.raw;
+    init.body = request.body;
   }
 
   return new NodeRequest(url, init);


### PR DESCRIPTION
I just got to the bottom of debugging why `await request.text()` was always returning an empty string in my remix action. Making this change resolved the issue.

I'm curious if I'm missing some context as to why you'd be passing the whole request as the body parameter `new Request`