### PR TITLE
fix: use normalized path for static files.

### DIFF
--- a/.changeset/some-unique-id.md
+++ b/.changeset/some-unique-id.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": patch
+---
+
+Uses the normalized path for `filePublicPath`.

--- a/packages/remix-fastify/src/utils.ts
+++ b/packages/remix-fastify/src/utils.ts
@@ -48,7 +48,7 @@ export function getStaticFiles({
 
       return {
         isBuildAsset,
-        filePublicPath: filePublicPath.replace("public/", ""),
+        filePublicPath: normalized.replace("public/", ""),
         browserAssetUrl,
       };
     });


### PR DESCRIPTION
Currently, `filePublicPath` is calculated off of the unnormalized version of the path, so "public/" doesn't match anything on Windows systems.  This leads to `reply.sendFile` trying to read from a file that likely does not exist, since it tries to use `path.join(process.cwd(), "public")` as the root.