### PR TITLE
fix: make this work without node --watch

### DIFF
--- a/.changeset/six-lizards-float.md
+++ b/.changeset/six-lizards-float.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": patch
+---
+
+move glob inside onRequest hook in order for getStaticFiles to be called. doing this allows the removal of node --watch which i totally didn't realize was restarting the server as we import the build 😅

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev --manual -c \"node --watch ./server.js\"",
+    "dev": "remix dev --manual -c \"node ./server.js\"",
     "start": "node ./server.js",
     "typecheck": "tsc"
   },

--- a/packages/remix-fastify/src/utils.ts
+++ b/packages/remix-fastify/src/utils.ts
@@ -2,7 +2,7 @@ import type { EarlyHintItem } from "@fastify/early-hints";
 import type { ServerBuild } from "@remix-run/node";
 import { matchRoutes } from "@remix-run/router";
 import type { FastifyRequest } from "fastify";
-import { globSync } from "glob";
+import { glob } from "glob";
 
 export interface StaticFile {
   // whether or not the file is in the build directory
@@ -13,7 +13,7 @@ export interface StaticFile {
   browserAssetUrl: string;
 }
 
-export function getStaticFiles({
+export async function getStaticFiles({
   assetsBuildDirectory,
   publicPath,
   rootDir,
@@ -21,8 +21,8 @@ export function getStaticFiles({
   assetsBuildDirectory: string;
   publicPath: string;
   rootDir: string;
-}): Array<StaticFile> {
-  let staticFilePaths = globSync(`**/*`, {
+}): Promise<Array<StaticFile>> {
+  let staticFilePaths = await glob(`**/*`, {
     dot: true,
     nodir: true,
     cwd: rootDir,

--- a/playground/app/routes/_layout._index.tsx
+++ b/playground/app/routes/_layout._index.tsx
@@ -81,13 +81,19 @@ export default function Index() {
 }
 
 function NameInput() {
-  let resolvedName = useAsyncValue() as string;
-  let defaultValue = resolvedName === "Anonymous" ? "" : resolvedName;
+  let resolvedName = useAsyncValue();
+  let defaultValue: string | undefined = undefined;
+  if (typeof resolvedName === "string") {
+    if (resolvedName !== "Anonymous") {
+      defaultValue = resolvedName;
+    }
+  }
+
   return (
     <input
       type="text"
       name="name"
-      title="Enter your name"
+      placeholder="Enter your name"
       defaultValue={defaultValue}
     />
   );

--- a/playground/package.json
+++ b/playground/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev --manual -c \"node --watch ./server.js\"",
+    "dev": "remix dev --manual -c \"node ./server.js\"",
     "start": "node ./server.js",
     "lint": "eslint --cache --ignore-path .gitignore --fix .",
     "format": "prettier --write --ignore-path .gitignore .",

--- a/playground/server.js
+++ b/playground/server.js
@@ -31,7 +31,7 @@ app.addContentTypeParser("*", noopContentParser);
 await app.register(fastifyEarlyHints, { warn: true });
 
 // match with remix.config
-app.register(staticFilePlugin, {
+await app.register(staticFilePlugin, {
   assetsBuildDirectory: "public/build",
   publicPath: "/modules/",
 });


### PR DESCRIPTION
move glob inside onRequest hook in order for getStaticFiles to be called. doing this allows the removal of `node --watch` which i totally didn't realize was restarting the server as we import the build 😅 