### PR TITLE
fix(examples/vite): use static module id as the variable isn’t exported anymore

### DIFF
--- a/examples/unstable-vite/server.js
+++ b/examples/unstable-vite/server.js
@@ -5,7 +5,6 @@ import { fastifyStatic } from "@fastify/static";
 import { createRequestHandler } from "@mcansh/remix-fastify";
 import { installGlobals } from "@remix-run/node";
 import { fastify } from "fastify";
-import { unstable_viteServerBuildModuleId } from "@remix-run/dev";
 
 installGlobals();
 
@@ -65,7 +64,7 @@ app.all("*", async (request, reply) => {
   try {
     let handler = createRequestHandler({
       build: vite
-        ? () => vite?.ssrLoadModule(unstable_viteServerBuildModuleId)
+        ? () => vite?.ssrLoadModule("virtual:remix/server-build")
         : await import("./build/server/index.js"),
     });
     return handler(request, reply);


### PR DESCRIPTION
follow up to #222 
closes #226