### PR TITLE
fix: move `chokidar` to `devDependencies`

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -17,7 +17,6 @@
     "@remix-run/node": "^2.4.1",
     "@remix-run/react": "^2.4.1",
     "@remix-run/serve": "^2.4.1",
-    "chokidar": "^3.5.3",
     "fastify": "^4.25.2",
     "isbot": "^4.1.0",
     "react": "^18.2.0",
@@ -29,6 +28,7 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "eslint": "^8.56.0",
+    "chokidar": "^3.5.3",
     "typescript": "^5.3.3"
   },
   "engines": {


### PR DESCRIPTION
`chokidar` should be a development dependency, since it's only used in `createDevRequestHandler`.