### PR TITLE
feat: allow http2/https servers

### DIFF
--- a/.changeset/gentle-dingos-sit.md
+++ b/.changeset/gentle-dingos-sit.md
@@ -1,0 +1,13 @@
+---
+"@mcansh/remix-fastify": patch
+---
+
+feat: allow http2/https servers
+
+previously using `fastify({ http2: true })` or `fastify({ https: {...} })` resulted in type errors for the handler when passing the request
+![image](https://github.com/mcansh/remix-fastify/assets/11698668/7a02b889-a9a9-4ddb-8686-ef6cda8d1bae)
+
+this has been fixed by passing the server type to all uses of the request and reply internally
+![image](https://github.com/mcansh/remix-fastify/assets/11698668/ff23882b-c169-4b61-bc5f-90683c52fc1b)
+
+this PR allows any server that extends `http.Server | https.Server | http2.Http2Server | http2.Http2SecureServer;`

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm run --filter remix-fastify --filter playground --recursive --parallel dev",
+    "dev:vite": "pnpm run --filter remix-fastify --filter vite-remix --recursive --parallel dev",
     "build": "pnpm run --recursive build",
     "test": "pnpm --filter ./packages/* test --if-present",
     "publish": "./scripts/publish.js",


### PR DESCRIPTION
previously using `fastify({ http2: true })` resulted in type errors for the handler when passing the request
![image](https://github.com/mcansh/remix-fastify/assets/11698668/7a02b889-a9a9-4ddb-8686-ef6cda8d1bae)

this has been fixed by passing the server type to all uses of the request and reply internally
![image](https://github.com/mcansh/remix-fastify/assets/11698668/ff23882b-c169-4b61-bc5f-90683c52fc1b)

the changes in this PR also give us `https` support as we allow any of `http.Server | https.Server | http2.Http2Server | http2.Http2SecureServer;` to be used as far as types go.