### PR TITLE
examples: encapsulate catch all route for remix to allow for other routes content parsers

### DIFF
--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -31,16 +31,6 @@ if (process.env.NODE_ENV === "development") {
 
 let app = fastify();
 
-// by default fastify parses application/json and text/plain payloads, we want remix to parse all content types
-// if you have routes outside of Remix that need to parse JSON, you can parse the json in the route handler
-// see the following gist for an example https://gist.github.com/mcansh/80b4cefa4075e157326273de52e50ae1
-app.addContentTypeParser(
-  ["application/json", "text/plain", "*"],
-  (_request, payload, done) => {
-    done(null, payload);
-  },
-);
-
 await app.register(fastifyEarlyHints, { warn: true });
 
 await app.register(fastifyStatic, {
@@ -69,13 +59,28 @@ await app.register(fastifyStatic, {
   lastModified: true,
 });
 
-app.all("*", async (request, reply) => {
-  if (process.env.NODE_ENV === "production") {
-    let links = getEarlyHintLinks(request, initialBuild);
-    await reply.writeEarlyHintsLinks(links);
-  }
+app.register(async function (childServer) {
+  childServer.removeAllContentTypeParsers();
 
-  return handler(request, reply);
+  // allow all content types
+  childServer.addContentTypeParser("*", (_request, payload, done) => {
+    done(null, payload);
+  });
+
+  // handle SSR requests
+  childServer.all("*", async (request, reply) => {
+    if (process.env.NODE_ENV === "production") {
+      let links = getEarlyHintLinks(request, initialBuild);
+      await reply.writeEarlyHintsLinks(links);
+    }
+
+    try {
+      return handler(request, reply);
+    } catch (error) {
+      console.error(error);
+      return reply.status(500).send(error);
+    }
+  });
 });
 
 let port = process.env.PORT ? Number(process.env.PORT) || 3000 : 3000;

--- a/examples/playground/app/routes/_layout._index.tsx
+++ b/examples/playground/app/routes/_layout._index.tsx
@@ -53,6 +53,7 @@ export async function action({ request }: DataFunctionArgs) {
 
 export default function Index() {
   let data = useLoaderData<typeof loader>();
+  const [echo, setEcho] = React.useState<string | null>(null);
 
   return (
     <div>
@@ -76,11 +77,46 @@ export default function Index() {
             </Await>
           </React.Suspense>
         </label>
-        <button type="submit">Submit</button>
-        <button name="reset" type="submit">
+        <button name="intent" value="submit" type="submit">
+          Submit
+        </button>
+        <button name="intent" value="reset" type="submit">
           Reset
         </button>
       </Form>
+
+      <form
+        method="post"
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: 4,
+          marginTop: 16,
+          flexDirection: "column",
+        }}
+        action="/api/echo"
+        onSubmit={async (event) => {
+          event.preventDefault();
+          let formData = new FormData(event.currentTarget);
+          let response = await fetch(event.currentTarget.action, {
+            method: event.currentTarget.method,
+            body: JSON.stringify(Object.fromEntries(formData.entries())),
+            headers: {
+              "Content-Type": "application/json",
+            },
+          });
+          let json = await response.json();
+          setEcho(json);
+        }}
+      >
+        <div>
+          <input type="text" name="text" />
+          <button name="intent" type="submit" value="echo">
+            Echo
+          </button>
+        </div>
+        {echo ? <pre>{JSON.stringify(echo)}</pre> : null}
+      </form>
     </div>
   );
 }

--- a/examples/unstable-vite/server.js
+++ b/examples/unstable-vite/server.js
@@ -12,20 +12,10 @@ let vite =
   process.env.NODE_ENV === "production"
     ? undefined
     : await import("vite").then((m) =>
-        m.createServer({ server: { middlewareMode: true } })
+        m.createServer({ server: { middlewareMode: true } }),
       );
 
 let app = fastify();
-
-// by default fastify parses application/json and text/plain payloads, we want remix to parse all content types
-// if you have routes outside of Remix that need to parse JSON, you can parse the json in the route handler
-// see the following gist for an example https://gist.github.com/mcansh/80b4cefa4075e157326273de52e50ae1
-app.addContentTypeParser(
-  ["application/json", "text/plain", "*"],
-  (_request, payload, done) => {
-    done(null, payload);
-  },
-);
 
 let __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
@@ -62,19 +52,27 @@ await app.register(fastifyStatic, {
   lastModified: true,
 });
 
-// handle SSR requests
-app.all("*", async (request, reply) => {
-  try {
-    let handler = createRequestHandler({
-      build: vite
-        ? () => vite?.ssrLoadModule("virtual:remix/server-build")
-        : await import("./build/server/index.js"),
-    });
-    return handler(request, reply);
-  } catch (error) {
-    console.error(error);
-    return reply.status(500).send(error);
-  }
+app.register(async function (childServer) {
+  childServer.removeAllContentTypeParsers();
+  // allow all content types
+  childServer.addContentTypeParser("*", (_request, payload, done) => {
+    done(null, payload);
+  });
+
+  // handle SSR requests
+  childServer.all("*", async (request, reply) => {
+    try {
+      let handler = createRequestHandler({
+        build: vite
+          ? () => vite?.ssrLoadModule("virtual:remix/server-build")
+          : await import("./build/server/index.js"),
+      });
+      return handler(request, reply);
+    } catch (error) {
+      console.error(error);
+      return reply.status(500).send(error);
+    }
+  });
 });
 
 let port = Number(process.env.PORT) || 3000;


### PR DESCRIPTION
closes #244

suggestion found by @⁠adaboese [fastify/fastify#5306 (comment)](https⁠://github.com/fastify/fastify/discussions/5306#discussioncomment-8399986)

Signed-off-by: Logan McAnsh <logan@mcan.sh>
