### PR TITLE
chore(example): dont register `@fastify/static` in development

### DIFF
--- a/examples/vite/server.js
+++ b/examples/vite/server.js
@@ -38,19 +38,19 @@ if (vite) {
     serveDotFiles: true,
     lastModified: true,
   });
-}
 
-await app.register(fastifyStatic, {
-  root: path.join(__dirname, "build", "client"),
-  prefix: "/",
-  wildcard: false,
-  cacheControl: true,
-  dotfiles: "allow",
-  etag: true,
-  maxAge: "1h",
-  serveDotFiles: true,
-  lastModified: true,
-});
+  await app.register(fastifyStatic, {
+    root: path.join(__dirname, "build", "client"),
+    prefix: "/",
+    wildcard: false,
+    cacheControl: true,
+    dotfiles: "allow",
+    etag: true,
+    maxAge: "1h",
+    serveDotFiles: true,
+    lastModified: true,
+  });
+}
 
 app.register(async function (childServer) {
   childServer.removeAllContentTypeParsers();


### PR DESCRIPTION
vite will serve everything from its middlewares so registering any of the instances of `@fastify/static` are unnecessary

closes #288 

Signed-off-by: Logan McAnsh <logan@mcan.sh>