### PR TITLE
feat: move plugin to subpath import

### DIFF
--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -12,7 +12,6 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@fastify/middie": "^8.3.0",
     "@fastify/static": "^7.0.3",
     "@mcansh/remix-fastify": "3.3.0",
     "@remix-run/node": "*",
@@ -24,6 +23,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@fastify/middie": "^8.3.0",
     "@remix-run/dev": "*",
     "@remix-run/eslint-config": "*",
     "@types/react": "^18.2.79",

--- a/packages/remix-fastify/README.md
+++ b/packages/remix-fastify/README.md
@@ -13,6 +13,19 @@ These are the currently available templates that you can get jump started with:
   ```
 
 - The basic example using the old Remix compiler
+
   ```sh
   npx create-remix@latest --template mcansh/remix-fastify/examples/basic
   ```
+
+## Installation
+
+```sh
+npm i @mcansh/remix-fastify
+```
+
+if you're using the fastify plugin, you'll also need to install
+
+```sh
+npm i -D @fastify/middie && npm i @fastify/static
+```

--- a/packages/remix-fastify/package.json
+++ b/packages/remix-fastify/package.json
@@ -22,6 +22,16 @@
   "type": "module",
   "exports": {
     "./package.json": "./package.json",
+    "./plugin": {
+      "types": {
+        "require": "./dist/plugin.d.cts",
+        "import": "./dist/plugin.d.ts",
+        "default": "./dist/plugin.d.cts"
+      },
+      "require": "./dist/plugin.cjs",
+      "import": "./dist/plugin.js",
+      "default": "./dist/plugin.cjs"
+    },
     ".": {
       "types": {
         "require": "./dist/index.d.cts",
@@ -52,12 +62,12 @@
     "validate": "run-p typecheck test"
   },
   "dependencies": {
-    "@fastify/middie": "^8.3.0",
-    "@fastify/static": "^7.0.3",
     "@remix-run/router": "^1.16.0",
     "fastify-plugin": "^4.5.1"
   },
   "devDependencies": {
+    "@fastify/middie": "^8.3.0",
+    "@fastify/static": "^7.0.3",
     "@remix-run/node": "^2.9.0",
     "@types/node": "^20.12.7",
     "@typescript/lib-dom": "npm:@types/web@^0.0.143",
@@ -67,11 +77,19 @@
     "vite": "^5.2.10"
   },
   "peerDependencies": {
+    "@fastify/middie": "^8.0.0",
+    "@fastify/static": "^7.0.0",
     "@remix-run/node": "^2.0.0",
     "fastify": "^3.29.0 || ^4.0.0",
     "vite": "^5.0.0"
   },
   "peerDependenciesMeta": {
+    "@fastify/middie": {
+      "optional": true
+    },
+    "@fastify/static": {
+      "optional": true
+    },
     "vite": {
       "optional": true
     }

--- a/packages/remix-fastify/src/index.ts
+++ b/packages/remix-fastify/src/index.ts
@@ -1,4 +1,2 @@
 export type { GetLoadContextFunction, RequestHandler } from "./server";
 export { createRequestHandler } from "./server";
-export { remixFastify } from "./plugin";
-export type { RemixFastifyOptions } from "./plugin";

--- a/packages/remix-fastify/tsup.config.ts
+++ b/packages/remix-fastify/tsup.config.ts
@@ -4,14 +4,14 @@ import pkg from "./package.json";
 
 export default defineConfig(() => {
   return {
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/plugin.ts"],
     sourcemap: true,
     tsconfig: "./tsconfig.json",
     dts: true,
     format: ["cjs", "esm"],
     clean: true,
     cjsInterop: true,
-    splitting: true,
+    splitting: false,
     platform: "node",
     skipNodeModulesBundle: true,
     treeshake: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,9 +207,6 @@ importers:
 
   examples/vite:
     dependencies:
-      '@fastify/middie':
-        specifier: ^8.3.0
-        version: 8.3.0
       '@fastify/static':
         specifier: ^7.0.3
         version: 7.0.3
@@ -268,12 +265,6 @@ importers:
 
   packages/remix-fastify:
     dependencies:
-      '@fastify/middie':
-        specifier: ^8.3.0
-        version: 8.3.0
-      '@fastify/static':
-        specifier: ^7.0.3
-        version: 7.0.3
       '@remix-run/router':
         specifier: ^1.16.0
         version: 1.16.0
@@ -281,6 +272,12 @@ importers:
         specifier: ^4.5.1
         version: 4.5.1
     devDependencies:
+      '@fastify/middie':
+        specifier: ^8.3.0
+        version: 8.3.0
+      '@fastify/static':
+        specifier: ^7.0.3
+        version: 7.0.3
       '@remix-run/node':
         specifier: ^2.9.0
         version: 2.9.0(typescript@5.4.5)


### PR DESCRIPTION
just an idea..

this means if you don't use the plugin you won't be unnecessarily installing `@fastify/static` and `@fastify/middie`, but if you do then you'll need to handle installing those yourself..