### PR TITLE
Swap out tsm for tsx

### DIFF
--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "remix vite:build && tsc --project ./tsconfig.server.json",
-    "dev": "cross-env NODE_ENV=development node --loader tsm --enable-source-maps --watch-path ./server/index.ts ./server/index.ts",
+    "dev": "cross-env NODE_ENV=development tsx --enable-source-maps --watch-path ./server/index.ts ./server/index.ts",
     "lint": "eslint --ignore-path .gitignore --no-error-on-unmatched-pattern --cache --cache-location node_modules/.cache/eslint --fix .",
     "format": "prettier --ignore-path .gitignore --ignore-unknown --cache --cache-location node_modules/.cache/prettiercache --write .",
     "start": "cross-env NODE_ENV=production node --enable-source-maps ./server/index.js",
@@ -30,7 +30,7 @@
     "@types/react-dom": "^18.3.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
-    "tsm": "^2.3.0",
+    "tsx": "^4.16.2",
     "typescript": "^5.4.5",
     "vite": "^5.3.2",
     "vite-tsconfig-paths": "^4.3.2"


### PR DESCRIPTION
TSX is actively maintained (e.g., no node loader warning), more widely adopted, and better documented than TSM.