### PR TITLE
feat: accept fastify/static plugin options

### DIFF
--- a/.changeset/tender-bananas-promise.md
+++ b/.changeset/tender-bananas-promise.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": patch
+---
+
+New optional parameter to customize the `@fastify/static` plugin options. This can be useful to customize options like `decorateReply` or `setHeaders` to match your needs or when you already have a `@fastify/static` plugin registered.

--- a/packages/remix-fastify/src/plugin.ts
+++ b/packages/remix-fastify/src/plugin.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import url from "node:url";
 import fp from "fastify-plugin";
 import type { InlineConfig, ViteDevServer } from "vite";
-import fastifyStatic from "@fastify/static";
+import fastifyStatic, { type FastifyStaticOptions } from "@fastify/static";
 import { cacheHeader } from "pretty-cache-header";
 
 import { createRequestHandler } from "./server";
@@ -41,6 +41,10 @@ export type RemixFastifyOptions = {
    */
   viteOptions?: InlineConfig;
   /**
+   * Options to pass to the `@fastify/static` plugin for serving compiled assets in production.
+   */
+  fastifyStaticOptions?: FastifyStaticOptions;
+  /**
    * The cache control options to use for build assets in production.
    * uses `pretty-cache-header` under the hood.
    * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
@@ -66,6 +70,7 @@ export let remixFastify = fp<RemixFastifyOptions>(
       getLoadContext,
       mode = process.env.NODE_ENV,
       viteOptions,
+      fastifyStaticOptions,
       assetCacheControl = { public: true, maxAge: "1 year", immutable: true },
       defaultCacheControl = { public: true, maxAge: "1 hour" },
     },
@@ -120,6 +125,7 @@ export let remixFastify = fp<RemixFastifyOptions>(
               : cacheHeader(defaultCacheControl),
           );
         },
+        ...fastifyStaticOptions,
       });
     }
 


### PR DESCRIPTION
We have a use case where we would like to customize parameters like `decorateReply` or `setHeaders` in the `@fastify/static` plugin.

This PR accepts and forwards or overrides options to the plugin. This can be useful if you want to disable the `decorateReply` parameter, set more custom headers, or set other stuff.

Example use case:
```ts
const app = fastify();

// Let's say you have already registered the same `@fastify/static` plugin in your app.
app.register(fastifyStatic, { /* ... */ });
app.register(remixFastify, {
  fastifyStaticOptions: {
    decorateReply: false  // Then this parameter is needed, otherwise it will throw an error from Fastify
  }
});
```