### PR TITLE
feat: accept custom production server build

### DIFF
--- a/.changeset/tender-plums-taste.md
+++ b/.changeset/tender-plums-taste.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": patch
+---
+
+New optional parameter to provide a custom server build for production. If not provided, it will be loaded using `import()` with the server build path provided in the options.

--- a/packages/remix-fastify/src/plugin.ts
+++ b/packages/remix-fastify/src/plugin.ts
@@ -60,7 +60,7 @@ export type RemixFastifyOptions = {
    *
    * If not provided, it will be loaded using `import()` with the server build path provided in the options.
    */
-  productionServerBuild?: ServerBuild | (() => Promise<ServerBuild>);
+  productionServerBuild?: ServerBuild | (() => ServerBuild | Promise<ServerBuild>);
 };
 
 export let remixFastify = fp<RemixFastifyOptions>(

--- a/packages/remix-fastify/src/plugin.ts
+++ b/packages/remix-fastify/src/plugin.ts
@@ -60,7 +60,9 @@ export type RemixFastifyOptions = {
    *
    * If not provided, it will be loaded using `import()` with the server build path provided in the options.
    */
-  productionServerBuild?: ServerBuild | (() => ServerBuild | Promise<ServerBuild>);
+  productionServerBuild?:
+    | ServerBuild
+    | (() => ServerBuild | Promise<ServerBuild>);
 };
 
 export let remixFastify = fp<RemixFastifyOptions>(

--- a/packages/remix-fastify/src/server.ts
+++ b/packages/remix-fastify/src/server.ts
@@ -50,7 +50,7 @@ export function createRequestHandler<Server extends HttpServer>({
   getLoadContext,
   mode = process.env.NODE_ENV,
 }: {
-  build: ServerBuild | (() => Promise<ServerBuild>);
+  build: ServerBuild | (() => ServerBuild | Promise<ServerBuild>);
   getLoadContext?: GetLoadContextFunction<Server>;
   mode?: string;
 }): RequestHandler<Server> {


### PR DESCRIPTION
This PR allows you to pass a custom production server build to the request handler. In some situations, you might want to load the server build using a different approach. (for example, use `require` instead of `import` or pass the object from the memory)

We need this because our runtime setup prevents us from using the default dynamic import approach. We would like to have an option that allows us to manually pass the server build without basically building the same `remix-fastify` plugin with the helper functions provided.

This parameter is better suited to advanced users, while the default dynamic import approach should be sufficient for normal users.