### PR TITLE
fix asset serving when using a basename

### DIFF
--- a/.changeset/cyan-suits-kneel.md
+++ b/.changeset/cyan-suits-kneel.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": patch
+---
+
+fix asset serving when using a basename

--- a/packages/remix-fastify/src/plugin.ts
+++ b/packages/remix-fastify/src/plugin.ts
@@ -83,7 +83,7 @@ export let remixFastify = fp<RemixFastifyOptions>(
       assetCacheControl = { public: true, maxAge: "1 year", immutable: true },
       defaultCacheControl = { public: true, maxAge: "1 hour" },
       productionServerBuild,
-    },
+    }
   ) => {
     let cwd = process.env.REMIX_ROOT ?? process.cwd();
 
@@ -105,7 +105,7 @@ export let remixFastify = fp<RemixFastifyOptions>(
     let SERVER_BUILD = path.join(
       resolvedBuildDirectory,
       "server",
-      serverBuildFile,
+      serverBuildFile
     );
     let SERVER_BUILD_URL = url.pathToFileURL(SERVER_BUILD).href;
 
@@ -140,29 +140,30 @@ export let remixFastify = fp<RemixFastifyOptions>(
             "cache-control",
             isAsset
               ? cacheHeader(assetCacheControl)
-              : cacheHeader(defaultCacheControl),
+              : cacheHeader(defaultCacheControl)
           );
         },
         ...fastifyStaticOptions,
       });
     }
 
-    fastify.register(async function createRemixRequestHandler(childServer) {
-      // remove the default content type parsers
-      childServer.removeAllContentTypeParsers();
-      // allow all content types
-      childServer.addContentTypeParser("*", (_request, payload, done) => {
-        done(null, payload);
-      });
+    fastify.register(
+      async function createRemixRequestHandler(childServer) {
+        // remove the default content type parsers
+        childServer.removeAllContentTypeParsers();
+        // allow all content types
+        childServer.addContentTypeParser("*", (_request, payload, done) => {
+          done(null, payload);
+        });
 
-      let basepath = basename.replace(/\/+$/, "") + "/*";
-
-      childServer.all(basepath, remixHandler);
-    });
+        childServer.all("*", remixHandler);
+      },
+      { prefix: basename }
+    );
   },
   {
     // replaced with the package name during build
     name: process.env.__PACKAGE_NAME__,
     fastify: "4.x",
-  },
+  }
 );

--- a/packages/remix-fastify/src/plugin.ts
+++ b/packages/remix-fastify/src/plugin.ts
@@ -127,7 +127,7 @@ export let remixFastify = fp<RemixFastifyOptions>(
       let ASSET_DIR = path.join(BUILD_DIR, "assets");
       await fastify.register(fastifyStatic, {
         root: BUILD_DIR,
-        prefix: "/",
+        prefix: basename,
         wildcard: false,
         cacheControl: true,
         dotfiles: "allow",


### PR DESCRIPTION
Hey when I use the basename in remix vite plugin and set base in vite locally assets are served at the same basename. But when using your plugin assets are still served at the root in production mode. So just made the change to respect the basename path.

If you want something that is more flexible let me know.

```
export default defineConfig({
  base: "/platform/",
  plugins: [
    remix({
      basename: "/platform/",
    }),
  ],
})
```