### PR TITLE
fix(plugin): we're handling cache-control

### DIFF
--- a/.changeset/bright-pigs-promise.md
+++ b/.changeset/bright-pigs-promise.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": patch
+---
+
+Make cache-control headers work again.

--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -54,7 +54,7 @@ if (process.env.NODE_ENV === "production") {
     prefix: "/",
     wildcard: false,
     decorateReply: false,
-    cacheControl: true,
+    cacheControl: false,
     dotfiles: "allow",
     etag: true,
     serveDotFiles: true,
@@ -67,18 +67,12 @@ await app.register(fastifyStatic, {
   root: BUILD_DIR,
   prefix: "/",
   wildcard: false,
-  cacheControl: true,
+  cacheControl: false,
   dotfiles: "allow",
   etag: true,
   serveDotFiles: true,
   lastModified: true,
-  setHeaders(res, filepath) {
-    let isAsset = filepath.startsWith(BUILD_DIR);
-    res.setHeader(
-      "cache-control",
-      isAsset ? ASSET_CACHE_CONTROL : DEFAULT_CACHE_CONTROL,
-    );
-  },
+  setHeaders,
 });
 
 app.register(async function createRemixRequestHandler(childServer) {

--- a/packages/remix-fastify/src/plugin.ts
+++ b/packages/remix-fastify/src/plugin.ts
@@ -133,7 +133,7 @@ export const remixFastify = fp<RemixFastifyOptions>(
         root: BUILD_DIR,
         prefix: basename,
         wildcard: false,
-        cacheControl: true,
+        cacheControl: false, // required because we are setting custom cache-control headers in setHeaders
         dotfiles: "allow",
         etag: true,
         serveDotFiles: true,


### PR DESCRIPTION
It turns out that if you set "cacheControl: true" in the options to @fastify/static, it overrides the headers you set in the setHeaders callback.  This bug was introduced to remix-fastify in April 2024 in this commit:

https://github.com/mcansh/remix-fastify/commit/a7fcb6da513ce17ac106f0930373f3edd9d976c9

I identified the issue as I thought it was a bug with @fastify/static, which was discussed here: https://github.com/fastify/fastify-static/issues/477, but it was actually a bug with remix-fastify.

I will admit that the @fastify/static options are very unclear and not user friendly.