### PR TITLE
Eagerly load server build in Fastify plugin

### DIFF
--- a/.changeset/stupid-onions-float.md
+++ b/.changeset/stupid-onions-float.md
@@ -1,0 +1,5 @@
+---
+"@mcansh/remix-fastify": patch
+---
+
+eagerly build output

--- a/packages/remix-fastify/src/plugins/index.ts
+++ b/packages/remix-fastify/src/plugins/index.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
 import url from "node:url";
 
-import fastifyStatic from "@fastify/static";
 import type { FastifyStaticOptions } from "@fastify/static";
+import fastifyStatic from "@fastify/static";
 import type { FastifyInstance } from "fastify";
 import { cacheHeader } from "pretty-cache-header";
 import type { InlineConfig, ViteDevServer } from "vite";
@@ -126,10 +126,9 @@ export function createPlugin(
       mode,
       // @ts-expect-error - fix this
       getLoadContext,
-      // @ts-expect-error - fix this
       build: vite
         ? () => vite.ssrLoadModule(virtualModule)
-        : (productionServerBuild ?? (() => import(SERVER_BUILD_URL))),
+        : (productionServerBuild ?? (await import(SERVER_BUILD_URL))),
     });
 
     // handle asset requests


### PR DESCRIPTION
Previously, the server build was loaded lazily within the request handler in the Fastify plugin. This PR modifies the plugin to import and load the server build during plugin registration itself.

This change ensures the server build is ready when the first request arrives, eliminating the import cost and reducing latency for the initial user experience.