### PR TITLE
ci: restrict GitHub Actions token permissions

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-slim
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v5

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -10,6 +10,8 @@ concurrency:
 jobs:
   test:
     if: github.repository == 'mcansh/remix-fastify'
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
     with:
       os: '["ubuntu-slim", "macos-latest", "windows-latest"]'

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   test:
     if: github.repository == 'mcansh/remix-fastify'
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
     with:
       os: '["ubuntu-slim", "macos-latest", "windows-latest"]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ on:
         # so we'll need to manually stringify it for now
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ⚙️ Build

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -8,4 +8,12 @@ export default defineConfig({
   jsdoc: true,
   semi: false,
   printWidth: 80,
+  overrides: [
+    {
+      files: ["./packages/**/CHANGELOG.md"],
+      options: {
+        semi: true,
+      },
+    },
+  ],
 })

--- a/packages/react-router-fastify/src/fastify.ts
+++ b/packages/react-router-fastify/src/fastify.ts
@@ -50,7 +50,7 @@ export async function fastifyReactRouter(
 
   let serverBuild =
     devServer == null
-      ? build ?? createBuildLoader(devServer, path.resolve(serverBuildPath))
+      ? (build ?? createBuildLoader(devServer, path.resolve(serverBuildPath)))
       : createBuildLoader(devServer, path.resolve(serverBuildPath))
 
   if (devServer == null) {

--- a/packages/react-router-fastify/src/vite.test.ts
+++ b/packages/react-router-fastify/src/vite.test.ts
@@ -19,12 +19,16 @@ describe("fastifyReactRouterDev", () => {
     let plugin = fastifyReactRouterDev({ entry: "./server.ts" })
     let config = getHook<AnyHook>(plugin.config)
 
-    let result = await config?.call(undefined, {}, {
-      command: "serve",
-      mode: "development",
-      isPreview: false,
-      isSsrBuild: false,
-    })
+    let result = await config?.call(
+      undefined,
+      {},
+      {
+        command: "serve",
+        mode: "development",
+        isPreview: false,
+        isSsrBuild: false,
+      },
+    )
 
     expect(result).toEqual({
       ssr: {
@@ -37,12 +41,16 @@ describe("fastifyReactRouterDev", () => {
     let plugin = fastifyReactRouterDev({ entry: "./server.ts" })
     let config = getHook<AnyHook>(plugin.config)
 
-    let result = await config?.call(undefined, {}, {
-      command: "build",
-      mode: "production",
-      isPreview: false,
-      isSsrBuild: true,
-    })
+    let result = await config?.call(
+      undefined,
+      {},
+      {
+        command: "build",
+        mode: "production",
+        isPreview: false,
+        isSsrBuild: true,
+      },
+    )
 
     expect(result).toBeUndefined()
   })


### PR DESCRIPTION
This PR resolves GitHub code scanning alerts by explicitly scoping the `GITHUB_TOKEN` permissions used by GitHub Actions workflows.

- Grants read-only `contents` access to the reusable test workflow and the workflows that call it.
- Grants the cache cleanup job `actions: write` for deleting Actions caches and `contents: read` for checkout.
- Avoids inheriting broader repository default token permissions for the affected workflows.

## Validation

- Parsed all workflow YAML files with Ruby `YAML.load_file`.
- Checked the expected permissions on each affected workflow with focused Ruby assertions.
- Ran `git diff --check`.
- Ran `CI=true pnpm run lint`.
