### PR TITLE
ci: add vite dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,9 @@ updates:
         patterns:
           - "@tailwindcss/*"
           - tailwindcss
+      "vite":
+        patterns:
+          - "@vitejs/*"
+          - "@vitest/*"
+          - "vite"
+          - "vitest"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update grouping for Vite and Vitest-related packages, helping keep related updates organized and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->